### PR TITLE
Support more OSes (WIP)

### DIFF
--- a/lib/App/OS/Detect/MachineCores.pm
+++ b/lib/App/OS/Detect/MachineCores.pm
@@ -60,8 +60,13 @@ sub _build_cores {
         if ($self->os eq 'darwin')  { $cmd = 'sysctl hw.ncpu | awk \'{print \$2}\'' }
         if ($self->os eq 'MSWin32') { $cmd = 'echo %NUMBER_OF_PROCESSORS%' }
 
-        waitpid( open2(my $out, my $in, $cmd), 0);
-        $cores = <$out> + 0;
+        if ($cmd) {
+            waitpid( open2(my $out, my $in, $cmd), 0);
+            $cores = <$out> + 0;
+        }
+        else {
+            carp("Can't detect the cores for your system/OS, sorry.");
+        }
     }
 
     return $cores;


### PR DESCRIPTION
Hi,

I was assigned this for Feb in the PR challenge: 

http://blogs.perl.org/users/neilb/2014/12/take-the-2015-cpan-pull-request-challenge.html

So, this PR attempts to broaden the OS support. The `POSIX::sysconf` call should work on basically any *nix. If sysconf fails or we know it's not available, we fall back to a system-specific command to get num cores from /proc, environment, etc.

TODO:
- Check out robustness of sysconf across any platforms I can get my hands on.
- Create more fallbacks (multiple per-OS?).
- Count processors online vs processors configured?

I'm opening the PR at this stage to find out whether you like the look of the changes or not - if not, I'll back off. If so (or if I hear nothing), I'll continue :)

Thanks!
